### PR TITLE
Added a check for Linux/Darwin due to differences in stat syntax

### DIFF
--- a/kubectl.zsh
+++ b/kubectl.zsh
@@ -27,7 +27,12 @@ function _zsh_kubectl_prompt_precmd() {
     fi
 
     zstyle -s ':zsh-kubectl-prompt:' updated_at updated_at
-    if ! now="$(stat -c '%y' "$kubeconfig" 2>/dev/null)"; then
+    if [[ $(uname) == "Linux" ]]; then
+        now="$(stat -c '%y' "$kubeconfig" 2>/dev/null)"
+    elif [[ $(uname) == "Darwin" ]]; then
+        now="$(stat -f '%m' "$kubeconfig" 2>/dev/null)"
+    fi
+    if ! [[ -n $now ]]; then
         ZSH_KUBECTL_PROMPT="kubeconfig is not found"
         return 1
     fi

--- a/kubectl.zsh
+++ b/kubectl.zsh
@@ -32,7 +32,7 @@ function _zsh_kubectl_prompt_precmd() {
     elif [[ $(uname) == "Darwin" ]]; then
         now="$(stat -f '%m' "$kubeconfig" 2>/dev/null)"
     fi
-    if ! [[ -z $now ]]; then
+    if [[ -z "$now" ]]; then
         ZSH_KUBECTL_PROMPT="kubeconfig is not found"
         return 1
     fi

--- a/kubectl.zsh
+++ b/kubectl.zsh
@@ -32,7 +32,7 @@ function _zsh_kubectl_prompt_precmd() {
     elif [[ $(uname) == "Darwin" ]]; then
         now="$(stat -f '%m' "$kubeconfig" 2>/dev/null)"
     fi
-    if ! [[ -n $now ]]; then
+    if ! [[ -z $now ]]; then
         ZSH_KUBECTL_PROMPT="kubeconfig is not found"
         return 1
     fi


### PR DESCRIPTION
Added a small check because the stat command on OSX 10.11.6 seems to have a different syntax. I am not sure if the stat command syntax is always what I have provided but it is working well for me.