### PR TITLE
Change how to check stat command whether GNU coreutils or FreeBSD

### DIFF
--- a/kubectl.zsh
+++ b/kubectl.zsh
@@ -2,7 +2,7 @@ setopt prompt_subst
 autoload -U add-zsh-hook
 
 function() {
-    local namespace separator
+    local namespace separator modified_time_fmt
 
     # Specify the separator between context and namespace
     zstyle -s ':zsh-kubectl-prompt:' separator separator
@@ -15,28 +15,32 @@ function() {
     if [[ -z "$namespace" ]]; then
         zstyle ':zsh-kubectl-prompt:' namespace true
     fi
+
+    # Check the stat command because it has a different syntax between GNU coreutils and FreeBSD.
+    if stat --help >/dev/null 2>&1; then
+        modified_time_fmt='-c%y' # GNU coreutils
+    else
+        modified_time_fmt='-f%m' # FreeBSD
+    fi
+    zstyle ':zsh-kubectl-prompt:' modified_time_fmt $modified_time_fmt
 }
 
 add-zsh-hook precmd _zsh_kubectl_prompt_precmd
 function _zsh_kubectl_prompt_precmd() {
-    local kubeconfig updated_at now context namespace ns separator
+    local kubeconfig updated_at now context namespace ns separator modified_time_fmt
 
     kubeconfig="$HOME/.kube/config"
     if [[ -n "$KUBECONFIG" ]]; then
         kubeconfig="$KUBECONFIG"
     fi
 
-    zstyle -s ':zsh-kubectl-prompt:' updated_at updated_at
-    if [[ $(uname) == "Linux" ]]; then
-        now="$(stat -c '%y' "$kubeconfig" 2>/dev/null)"
-    elif [[ $(uname) == "Darwin" ]]; then
-        now="$(stat -f '%m' "$kubeconfig" 2>/dev/null)"
-    fi
-    if [[ -z "$now" ]]; then
+    zstyle -s ':zsh-kubectl-prompt:' modified_time_fmt modified_time_fmt
+    if ! now="$(stat $modified_time_fmt "$kubeconfig" 2>/dev/null)"; then
         ZSH_KUBECTL_PROMPT="kubeconfig is not found"
         return 1
     fi
 
+    zstyle -s ':zsh-kubectl-prompt:' updated_at updated_at
     if [[ "$updated_at" == "$now" ]]; then
         return 0
     fi


### PR DESCRIPTION
When GNU coreutils is used on Darwin, to check whether GNU coreutils or FreeBSD by `uname` doesn't work properly.