### PR TITLE
Enable the use of oh-my-zsh

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ This script displays information about the kubectl current context and namespace
 
 ## Usage
 
-
 Clone this repository and source the `kubectl.zsh` from your `~/.zshrc` config file, and configure your prompt.
+
 ```sh
 autoload -U colors; colors
 source /path/to/zsh-kubectl-prompt/kubectl.zsh
@@ -15,6 +15,7 @@ RPROMPT='%{$fg[blue]%}($ZSH_KUBECTL_PROMPT)%{$reset_color%}'
 ```
 
 Also you can install with homebrew.
+
 ```console
 $ brew tap superbrothers/zsh-kubectl-prompt
 $ brew install zsh-kubectl-prompt
@@ -23,11 +24,13 @@ $ brew install zsh-kubectl-prompt
 ## Customization
 
 Change the separator between context and namespace:
+
 ```sh
 zstyle ':zsh-kubectl-prompt:' separator '|'
 ```
 
 Does not display the current namespace:
+
 ```sh
 zstyle ':zsh-kubectl-prompt:' namespace false
 ```
@@ -35,6 +38,7 @@ zstyle ':zsh-kubectl-prompt:' namespace false
 ## With a plugin manager
 
 If you use [zgen](https://github.com/tarjoilija/zgen), load this repository as follows:
+
 ```sh
 source "${HOME}/.zgen/zgen.zsh"
 
@@ -52,6 +56,7 @@ RPROMPT='%{$fg[blue]%}($ZSH_KUBECTL_PROMPT)%{$reset_color%}'
 ```
 
 If you use [antigen](https://github.com/zsh-users/antigen), load this repository as follows:
+
 ```sh
 source /path-to-antigen/antigen.zsh
 
@@ -64,6 +69,22 @@ antigen apply
 autoload -U colors; colors
 RPROMPT='%{$fg[blue]%}($ZSH_KUBECTL_PROMPT)%{$reset_color%}'
 ```
+
+If you use [oh-my-zsh](https://ohmyz.sh/), load this repository as follows:
+
+1. Clone the repo into oh-my-zsh custom plugins folder
+
+```sh
+git clone git@github.com:superbrothers/zsh-kubectl-prompt.git ${ZSH_CUSTOM:-~/.oh-my-zsh/custom}/plugins/zsh-kubectl-prompt
+```
+
+2. Activate the plugin your `.zshrc` by appending it to the plugin section
+
+```sh
+plugins=( [plugins...] zsh-kubectl-prompt)
+```
+
+> **Note:** Remember to source the `.zshrc` or restart your shell after step 2
 
 ## License
 

--- a/zsh-kubectl-prompt.plugin.zsh
+++ b/zsh-kubectl-prompt.plugin.zsh
@@ -1,0 +1,1 @@
+source ${0:A:h}/kubectl.zsh


### PR DESCRIPTION
For oh-my-zsh to understand that this is a custom plugin it looks for plugin files with the ending `.plugin.zsh`[ref here](https://github.com/robbyrussell/oh-my-zsh/wiki/Customization). 

These changes will enable the use of oh-my-zsh with this plugin by creating a `.plugin` file that points to `kubectl.zsh`