### PR TITLE
Add optional vars before and after the prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,18 @@ Change the separator between context and namespace:
 zstyle ':zsh-kubectl-prompt:' separator '|'
 ```
 
+Add custom character before the prompt:
+
+```sh
+zstyle ':zsh-kubectl-prompt:' preprompt '<'
+```
+
+Add custom character after the prompt:
+
+```sh
+zstyle ':zsh-kubectl-prompt:' postprompt '>'
+```
+
 Does not display the current namespace:
 
 ```sh

--- a/kubectl.zsh
+++ b/kubectl.zsh
@@ -51,6 +51,7 @@ function _zsh_kubectl_prompt_precmd() {
     fi
     zstyle ':zsh-kubectl-prompt:' updated_at "$now"
 
+    # Set environment variable if context is not set
     if ! context="$(kubectl config current-context 2>/dev/null)"; then
         ZSH_KUBECTL_PROMPT="current-context is not set"
         return 1
@@ -62,14 +63,20 @@ function _zsh_kubectl_prompt_precmd() {
     [[ -z "$ns" ]] && ns="default"
     ZSH_KUBECTL_NAMESPACE="${ns}"
 
+    # Specify the entry before prompt (default empty)
+    zstyle -s ':zsh-kubectl-prompt:' preprompt preprompt
+    # Specify the entry after prompt (default empty)
+    zstyle -s ':zsh-kubectl-prompt:' postprompt postprompt
+
+    # Set environment variable without namespace
     zstyle -s ':zsh-kubectl-prompt:' namespace namespace
     if [[ "$namespace" != true ]]; then
-        ZSH_KUBECTL_PROMPT="${context}"
+        ZSH_KUBECTL_PROMPT="${preprompt}${context}${postprompt}"
         return 0
     fi
 
     zstyle -s ':zsh-kubectl-prompt:' separator separator
-    ZSH_KUBECTL_PROMPT="${context}${separator}${ns}"
+    ZSH_KUBECTL_PROMPT="${preprompt}${context}${separator}${ns}${postprompt}"
 
     return 0
 }


### PR DESCRIPTION
I have been adding custom characters around the prompt as I normally use the exported environment variable in the iTerm status bar). I thought this could be a nice thing to add to the plugin by default, as it already allows custom separator. I'm not sure you agree but as I've already created it for myself so I thought I would create a PR to check. 😄 

I took some images with different `zstyles` set to show how it looks. 

**Default:**
![Screenshot 2019-05-29 at 21 46 57](https://user-images.githubusercontent.com/23152018/58589433-2a530300-8262-11e9-94e5-f7c5dde644b5.png)

**Default(no namespace):**
![Screenshot 2019-05-29 at 21 47 23](https://user-images.githubusercontent.com/23152018/58589585-861d8c00-8262-11e9-9ed4-fc8dadbc7e25.png)

**Custom seperator:**
![Screenshot 2019-05-29 at 21 43 14](https://user-images.githubusercontent.com/23152018/58589633-9fbed380-8262-11e9-97d8-571a0b337850.png)

**Custom preprompt:**
![Screenshot 2019-05-29 at 21 44 44](https://user-images.githubusercontent.com/23152018/58589669-b107e000-8262-11e9-9e34-dd0a63e1c381.png)

**Custom postprompt:**
![Screenshot 2019-05-29 at 21 45 13](https://user-images.githubusercontent.com/23152018/58589696-bebd6580-8262-11e9-8896-2f43149a1756.png)

**No namepace with prompts:**
![Screenshot 2019-05-29 at 21 45 57](https://user-images.githubusercontent.com/23152018/58589612-96ce0200-8262-11e9-987d-d6a97c18a165.png)


