### PR TITLE
Add new feature about cluster info and change README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,11 +15,12 @@ RPROMPT='%{$fg[blue]%}($ZSH_KUBECTL_PROMPT)%{$reset_color%}'
 ```
 
 Or create different style depending on user, context, namespace.
-The plugin creates 4 variables:
+The plugin creates 5 variables:
 * ZSH_KUBECTL_CONTEXT
 * ZSH_KUBECTL_NAMESPACE
 * ZSH_KUBECTL_PROMPT
 * ZSH_KUBECTL_USER
+* ZSH_KUBECTL_CLUSTER
 
 For example, make the prompt red when the username matches admin.
 ```sh
@@ -38,10 +39,18 @@ $ brew install zsh-kubectl-prompt
 
 ## Customization
 
-Change the separator between context and namespace:
+Change the left separator between context and namespace or right separator between namespace and cluster:
+
+Add custom left separator:
 
 ```sh
-zstyle ':zsh-kubectl-prompt:' separator '|'
+zstyle ':zsh-kubectl-prompt:' left_separator '|'
+```
+
+Add custom right separator:
+
+```sh
+zstyle ':zsh-kubectl-prompt:' right_separator '@'
 ```
 
 Add custom character before the prompt:

--- a/kubectl.zsh
+++ b/kubectl.zsh
@@ -5,9 +5,15 @@ function() {
     local namespace separator_left separator_right modified_time_fmt
 
     # Specify the separator between context and namespace
+    zstyle -s ':zsh-kubectl-prompt:' separator separator
+    if [[ -n "$separator" ]]; then
+        zstyle ':zsh-kubectl-prompt:' separator_left "$separator"
+    fi
+
+    # Specify the separator between context and namespace
     zstyle -s ':zsh-kubectl-prompt:' separator_left separator_left
     if [[ -z "$separator_left" ]]; then
-        zstyle ':zsh-kubectl-prompt:' separator_left ':'
+        zstyle ':zsh-kubectl-prompt:' separator_left '/'
     fi
 
     # Specify the separator between namespace and cluster
@@ -25,7 +31,7 @@ function() {
 
 add-zsh-hook precmd _zsh_kubectl_prompt_precmd
 function _zsh_kubectl_prompt_precmd() {
-    local kubeconfig config updated_at now kube context namespace cluster ns separator_left separator_right modified_time_fmt
+    local kubeconfig config updated_at now context namespace cluster ns separator_left separator_right modified_time_fmt
 
     kubeconfig="$HOME/.kube/config"
     if [[ -n "$KUBECONFIG" ]]; then
@@ -71,6 +77,7 @@ function _zsh_kubectl_prompt_precmd() {
     ZSH_KUBECTL_NAMESPACE="${ns}"
     cluster="$(kubectl config view -o "jsonpath={.contexts[?(@.name==\"$context\")].context.cluster}")"
     ZSH_KUBECTL_CLUSTER="${cluster}"
+    ZSH_KUBECTL_CLUSTER_ENABLED=false
 
     # Specify the entry before prompt (default empty)
     zstyle -s ':zsh-kubectl-prompt:' preprompt preprompt
@@ -86,7 +93,13 @@ function _zsh_kubectl_prompt_precmd() {
 
     zstyle -s ':zsh-kubectl-prompt:' separator_left separator_left
     zstyle -s ':zsh-kubectl-prompt:' separator_right separator_right
-    ZSH_KUBECTL_PROMPT="${preprompt}${context}${separator_left}${ns}${separator_right}${cluster}${postprompt}"
+    
+    # Check if kubectl cluster need to be displayed
+    if [[ "${ZSH_KUBECTL_CLUSTER_ENABLED}" == "true" ]]; then
+        ZSH_KUBECTL_PROMPT="${preprompt}${context}${separator_left}${ns}${separator_right}${cluster}${postprompt}"
+    else
+        ZSH_KUBECTL_PROMPT="${preprompt}${context}${separator_left}${ns}${postprompt}"
+    fi
 
     return 0
 }


### PR DESCRIPTION
Hello. 

I made some changes, due to working with different clusters - usually I have the same hostname name on every production k8s cluster, so I need to know where I am.

I add cluster info in PROMPT and also changed separator - to have two - left and right. Default as ':' left and '@' as right.

![image](https://user-images.githubusercontent.com/7070961/90322191-7feffa00-df51-11ea-845d-438fd9793518.png)


Also changed README with following things. It's nothing special, but I guess it really helps in day to day working on different clusters.