### PR TITLE
Add a new parameter "binary"

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,12 @@ Does not display the current namespace:
 zstyle ':zsh-kubectl-prompt:' namespace false
 ```
 
+Use another binary instead of `kubectl` to get the information (e.g. `oc`):
+
+```sh
+zstyle ':zsh-kubectl-prompt:' binary 'oc'
+```
+
 ## With a plugin manager
 
 If you use [zgen](https://github.com/tarjoilija/zgen), load this repository as follows:


### PR DESCRIPTION
The binary parameter allows us to use the specified binary instead of
`kubectl` to get the information from kubeconfig.

For example, it allows OpenShift users to use `oc` command instead of
`kubectl`.