### PR TITLE
Removing typos in the README file to use copy button correctly

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,9 +39,9 @@ RPROMPT='$(right_prompt)'
 
 Also you can install with homebrew.
 
-```console
-$ brew tap superbrothers/zsh-kubectl-prompt
-$ brew install zsh-kubectl-prompt
+```sh
+brew tap superbrothers/zsh-kubectl-prompt
+brew install zsh-kubectl-prompt
 ```
 
 ## Customization


### PR DESCRIPTION
In the section of `brew` commands, when the copy button has been used, the character `$` is copied together with the brew command and It causes an error on the user terminal.

Removing the `$` character promotes the best experience for users.